### PR TITLE
Added anomaly logging & optional child details dict

### DIFF
--- a/task-sdk/src/airflow/sdk/definitions/anomaly_detection.py
+++ b/task-sdk/src/airflow/sdk/definitions/anomaly_detection.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import math
+from typing import Any
 
 import structlog
 
@@ -31,15 +32,32 @@ __all__ = [
 
 
 class AnomalyResult:
-    """Result of anomaly detection."""
+    """
+    Result of anomaly detection.
+
+    Parameters
+    ----------
+    is_anomaly : bool
+        Whether the latest runtime should be flagged as anomalous.
+
+    message : str
+        Human-readable summary of the anomaly evaluation. This is used in
+        parent detector logging and when emitting the anomaly payload.
+
+    details : dict[str, Any] | None
+        Optional structured fields supplied by the anomaly algorithm for the
+        parent detector to include in its logs.
+    """
 
     def __init__(
         self,
         is_anomaly: bool,
         message: str = "",
+        details: dict[str, Any] | None = None,
     ):
         self.is_anomaly = is_anomaly
         self.message = message
+        self.details = details or {}
 
 
 class AlwaysAnomaly:
@@ -49,7 +67,11 @@ class AlwaysAnomaly:
         pass
 
     def __call__(self, runtimes):
-        return AnomalyResult(True)
+        return AnomalyResult(
+            True,
+            message="AlwaysAnomaly marks every task instance as anomalous.",
+            details={"current_runtime": runtimes[-1]},
+        )
 
 
 class ThresholdAnomaly:
@@ -62,8 +84,24 @@ class ThresholdAnomaly:
     def __call__(self, runtimes):
         cur_runtime = runtimes[-1]
         if cur_runtime >= self.min_runtime and cur_runtime <= self.max_runtime:
-            return AnomalyResult(False)
-        return AnomalyResult(True)
+            return AnomalyResult(
+                False,
+                message="Runtime is within the configured threshold range.",
+                details={
+                    "current_runtime": cur_runtime,
+                    "min_runtime": None if math.isinf(self.min_runtime) else self.min_runtime,
+                    "max_runtime": None if math.isinf(self.max_runtime) else self.max_runtime,
+                },
+            )
+        return AnomalyResult(
+            True,
+            message="Runtime is outside the configured threshold range.",
+            details={
+                "current_runtime": cur_runtime,
+                "min_runtime": None if math.isinf(self.min_runtime) else self.min_runtime,
+                "max_runtime": None if math.isinf(self.max_runtime) else self.max_runtime,
+            },
+        )
 
 
 class AnomalyDetector:
@@ -73,7 +111,7 @@ class AnomalyDetector:
     Subclasses should override detect_anomalies().
     """
 
-    def __init__(self, min_runs: int, max_runs: int, algorithm=AlwaysAnomaly()):
+    def __init__(self, min_runs: int, max_runs: int, algorithm=None):
         """
         Initialize an anomaly detector configuration.
 
@@ -93,7 +131,7 @@ class AnomalyDetector:
         """
         self.min_runs = min_runs
         self.max_runs = max_runs
-        self.algorithm = algorithm
+        self.algorithm = algorithm or AlwaysAnomaly()
 
     def _get_historical_runtimes(self, ti) -> list[float]:
         """Fetch durations from prior successful task instances via supervisor comms."""
@@ -132,38 +170,67 @@ class AnomalyDetector:
         Imports are deferred to runtime so DAG parsing does not load execution modules.
         """
         log = structlog.get_logger(logger_name="task")
+        detector_name = type(self.algorithm).__name__
 
         ti = context.get("ti")
         if ti is None:
+            log.debug("Skipping anomaly detection due to missing task instance context")
             return
 
         start_date = getattr(ti, "start_date", None)
         end_date = getattr(ti, "end_date", None)
         if start_date is None or end_date is None:
+            log.debug(
+                "Anomaly detection skipped due to incomplete task instance timing",
+                has_start_date=start_date is not None,
+                has_end_date=end_date is not None,
+            )
             return
+
+        log.info(
+            "Anomaly detection started",
+            detector_name=detector_name,
+            min_runs=self.min_runs,
+            max_runs=self.max_runs,
+        )
 
         current_duration = (end_date - start_date).total_seconds()
         historical_runtimes = self._get_historical_runtimes(ti)
         runtimes = [*historical_runtimes, current_duration]
 
-        log.info("Retrieved runtimes:", found_runs=len(runtimes), runtimes=runtimes)
+        log.debug(
+            "Anomaly detection retrieved historical runtimes",
+            runs_considered=len(runtimes),
+            runtimes=runtimes,
+        )
 
         if len(runtimes) < self.min_runs:
-            log.debug(
-                "Skipping anomaly detection due to insufficient successful runs",
+            log.info(
+                "Anomaly detection skipped due to insufficient run count",
                 found_runs=len(runtimes),
                 required_runs=self.min_runs,
             )
             return
 
-        result = self.algorithm(runtimes)
+        try:
+            result = self.algorithm(runtimes)
+        except Exception:
+            log.exception("Anomaly detection evaluation failed", detector_name=detector_name)
+            return
+
+        log.info(
+            "Anomaly detection evaluated",
+            is_anomaly=str(result.is_anomaly),
+            reason=result.message,
+            **result.details,
+        )
 
         try:
             # Import runtime dependencies
             from airflow.sdk.execution_time.comms import RecordTaskAnomaly
             from airflow.sdk.execution_time.task_runner import SUPERVISOR_COMMS
         except Exception:
-            log.debug("Supervisor comms unavailable; skipping anomaly emit")
+            log.info("Anomaly detection emit skipped", reason="supervisor_comms_unavailable")
             return
 
         try:
@@ -175,9 +242,18 @@ class AnomalyDetector:
                     map_index=getattr(ti, "map_index", -1),
                     try_number=getattr(ti, "try_number", 0),
                     is_anomalous=bool(getattr(result, "is_anomaly", False)),
-                    detector_name=type(self.algorithm).__name__,
+                    detector_name=detector_name,
                     reason=(getattr(result, "message", "") or None),
                 )
             )
+            log.info(
+                "Anomaly payload emitted",
+                detector_name=detector_name,
+                is_anomaly=bool(getattr(result, "is_anomaly", False)),
+            )
         except Exception:
-            log.exception("Failed to emit anomaly payload")
+            log.exception(
+                "Failed to emit anomaly payload",
+                detector_name=detector_name,
+                is_anomaly=bool(getattr(result, "is_anomaly", False)),
+            )

--- a/task-sdk/src/airflow/sdk/definitions/anomaly_detection.py
+++ b/task-sdk/src/airflow/sdk/definitions/anomaly_detection.py
@@ -111,7 +111,7 @@ class AnomalyDetector:
     Subclasses should override detect_anomalies().
     """
 
-    def __init__(self, min_runs: int, max_runs: int, algorithm=None):
+    def __init__(self, min_runs: int, max_runs: int, algorithm=AlwaysAnomaly()):
         """
         Initialize an anomaly detector configuration.
 
@@ -131,7 +131,7 @@ class AnomalyDetector:
         """
         self.min_runs = min_runs
         self.max_runs = max_runs
-        self.algorithm = algorithm or AlwaysAnomaly()
+        self.algorithm = algorithm
 
     def _get_historical_runtimes(self, ti) -> list[float]:
         """Fetch durations from prior successful task instances via supervisor comms."""


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

* closes: #48
The purpose of this pull request is to improve anomaly detection logging and clarify the anomaly result interface.

This change includes:
- Logging when anomaly detection starts.
- Logging when anomaly detection is skipped because there are not enough successful historical runs.
- Logging when anomaly detection evaluation completes and whether the task instance was marked anomalous.
- Logging when anomaly payload emission succeeds or fails
- Moving detailed runtime collection output to debug-level logging to reduce noise in normal task logs.
- Updating built-in anomaly result handling so anomaly algorithms can return a human-readable message.
- Supporting optional structured `details` in `AnomalyResult` so child anomaly algorithms can provide extra context for parent-level logging.
- Updating `ThresholdAnomaly` and `AlwaysAnomaly` to return richer `AnomalyResult` values based on the addition of details above
- Adding documentation in `anomaly_detection.py` to explain the `AnomalyResult` fields and expected algorithm return contract.
- Updating the default algorithm to `None`, which gets updated to an `AlwaysAnomaly` inside of the init.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Generated-by: [Codex] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
