### PR TITLE
UI Improvements: Anomaly Indicators on Graph View

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/DagRunInfo.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DagRunInfo.tsx
@@ -19,6 +19,7 @@
 import { VStack, Text, Box, HStack } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
 import { FiAlertTriangle } from "react-icons/fi";
+import { Link as RouterLink } from "react-router-dom";
 
 import type { DAGRunResponse } from "openapi/requests/types.gen";
 import { StateBadge } from "src/components/StateBadge";
@@ -27,6 +28,7 @@ import { Tooltip } from "src/components/ui";
 import { getRelativeTime } from "src/utils/datetimeUtils";
 
 type Props = {
+  readonly anomalyUrl?: string;
   readonly endDate?: string | null;
   readonly isAnomalous?: boolean;
   readonly logicalDate?: string | null;
@@ -38,7 +40,7 @@ type Props = {
 const hasValue = (value: string | null | undefined): value is string =>
   value !== undefined && value !== null && value !== "";
 
-const DagRunInfo = ({ endDate, isAnomalous, logicalDate, runAfter, startDate, state }: Props) => {
+const DagRunInfo = ({ anomalyUrl, endDate, isAnomalous, logicalDate, runAfter, startDate, state }: Props) => {
   const { t: translate } = useTranslation("common");
 
   return (
@@ -87,8 +89,22 @@ const DagRunInfo = ({ endDate, isAnomalous, logicalDate, runAfter, startDate, st
               color="orange.600"
               flexShrink={0}
               lineHeight={0}
+              onClick={
+                anomalyUrl
+                  ? (e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                    }
+                  : undefined
+              }
             >
-              <FiAlertTriangle size={22} strokeWidth={2.75} />
+              {anomalyUrl ? (
+                <RouterLink to={anomalyUrl}>
+                  <FiAlertTriangle size={22} strokeWidth={2.75} />
+                </RouterLink>
+              ) : (
+                <FiAlertTriangle size={22} strokeWidth={2.75} />
+              )}
             </Box>
           ) : undefined}
         </HStack>

--- a/airflow-core/src/airflow/ui/src/components/Graph/TaskNode.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Graph/TaskNode.tsx
@@ -16,9 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, Button, Flex, HStack, LinkOverlay, Text } from "@chakra-ui/react";
+import { Badge, Box, Button, Flex, HStack, LinkOverlay, Text } from "@chakra-ui/react";
 import type { NodeProps, Node as NodeType } from "@xyflow/react";
 import { useTranslation } from "react-i18next";
+import { FiAlertTriangle } from "react-icons/fi";
 
 import { TaskIcon } from "src/assets/TaskIcon";
 import { StateBadge } from "src/components/StateBadge";
@@ -34,6 +35,7 @@ export const TaskNode = ({
     childCount,
     depth,
     height = 0,
+    isAnomalous,
     isGroup,
     isMapped,
     isOpen,
@@ -129,10 +131,24 @@ export const TaskNode = ({
               {isGroup ? translate("graph.taskGroup") : displayOperator}
             </Text>
             {taskInstance === undefined ? undefined : (
-              <HStack>
+              <HStack flexWrap="wrap" gap={1}>
                 <StateBadge fontSize="xs" state={taskInstance.state}>
                   {taskInstance.state}
                 </StateBadge>
+                {isAnomalous ? (
+                  <Badge
+                    borderRadius="full"
+                    colorPalette="red"
+                    fontSize="xs"
+                    gap={1}
+                    px={2}
+                    py={1}
+                    variant="solid"
+                  >
+                    <FiAlertTriangle size={10} strokeWidth={3} />
+                    {translate("anomaly", "Anomaly")}
+                  </Badge>
+                ) : undefined}
               </HStack>
             )}
             {isGroup ? (

--- a/airflow-core/src/airflow/ui/src/components/Graph/reactflowUtils.ts
+++ b/airflow-core/src/airflow/ui/src/components/Graph/reactflowUtils.ts
@@ -29,6 +29,7 @@ export type CustomNodeProps = {
   depth?: number;
   height?: number;
   id: string;
+  isAnomalous?: boolean;
   isGroup?: boolean;
   isMapped?: boolean;
   isOpen?: boolean;

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Graph/Graph.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Graph/Graph.tsx
@@ -23,7 +23,7 @@ import { useEffect } from "react";
 import { useParams, useSearchParams } from "react-router-dom";
 import { useLocalStorage } from "usehooks-ts";
 
-import { useStructureServiceStructureData } from "openapi/queries";
+import { useStructureServiceStructureData, useTaskInstanceAnomalyServiceGetTaskInstanceAnomalies } from "openapi/queries";
 import { DownloadButton } from "src/components/Graph/DownloadButton";
 import { edgeTypes, nodeTypes } from "src/components/Graph/graphTypes";
 import type { CustomNodeProps } from "src/components/Graph/reactflowUtils";
@@ -135,6 +135,29 @@ export const Graph = () => {
 
   const { data: gridTISummaries } = useGridTiSummaries({ dagId, runId });
 
+  const { data: tiAnomalyData } = useTaskInstanceAnomalyServiceGetTaskInstanceAnomalies(
+    { dagId: dagId || undefined, limit: 2000, offset: 0 },
+    undefined,
+    { enabled: Boolean(dagId) && Boolean(runId), refetchInterval: 5000 },
+  );
+
+  const anomalousCellKeys = new Set(
+    (tiAnomalyData?.task_instance_anomalies ?? [])
+      .filter((row) => row.dag_id === dagId && row.is_anomalous)
+      .map((row) => `${row.run_id}::${row.task_id}::${row.map_index}`),
+  );
+
+  const isTaskAnomalous = (taskNodeId: string) => {
+    if (anomalousCellKeys.has(`${runId}::${taskNodeId}::-1`)) return true;
+    const prefix = `${runId}::${taskNodeId}::`;
+
+    for (const key of anomalousCellKeys) {
+      if (key.startsWith(prefix)) return true;
+    }
+
+    return false;
+  };
+
   // Add task instances to the node data but without having to recalculate how the graph is laid out
   const nodes = data?.nodes.map((node) => {
     const taskInstance = gridTISummaries?.task_instances.find((ti) => ti.task_id === node.id);
@@ -143,6 +166,7 @@ export const Graph = () => {
       ...node,
       data: {
         ...node.data,
+        isAnomalous: isTaskAnomalous(node.id),
         isSelected: node.id === taskId || node.id === groupId || node.id === `dag:${dagId}`,
         taskInstance,
       },

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Graph/Graph.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Graph/Graph.tsx
@@ -148,11 +148,15 @@ export const Graph = () => {
   );
 
   const isTaskAnomalous = (taskNodeId: string) => {
-    if (anomalousCellKeys.has(`${runId}::${taskNodeId}::-1`)) return true;
+    if (anomalousCellKeys.has(`${runId}::${taskNodeId}::-1`)) {
+      return true;
+    }
     const prefix = `${runId}::${taskNodeId}::`;
 
     for (const key of anomalousCellKeys) {
-      if (key.startsWith(prefix)) return true;
+      if (key.startsWith(prefix)) {
+        return true;
+      }
     }
 
     return false;

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.tsx
@@ -92,6 +92,7 @@ export const DagCard = ({
             <Link asChild color="fg.info">
               <RouterLink to={`/dags/${latestRun.dag_id}/runs/${latestRun.run_id}`}>
                 <DagRunInfo
+                  anomalyUrl={`/dags/${dag.dag_id}/anomalies`}
                   endDate={latestRun.end_date}
                   isAnomalous={dagRunKeysWithAnomalousTasks.has(`${dag.dag_id}::${latestRun.run_id}`)}
                   logicalDate={latestRun.logical_date}


### PR DESCRIPTION
### **Summary**

- Added clickable anomaly indicator on the DAG list page: clicking the orange warning triangle now navigates directly to the Anomalies tab of that DAG (/dags/{dag_id}/anomalies), instead of staying on the run page

- Added anomaly warning indicator to the Graph view: tasks with detected anomalies now display a red "Anomaly" badge, matching the style already used in the Grid view
<img width="653" height="757" alt="Screenshot 2026-05-12 at 1 50 38 PM" src="https://github.com/user-attachments/assets/61ef9fcd-57e2-4de0-811e-fa48e32aff29" />
